### PR TITLE
Add another version for duplicate publication

### DIFF
--- a/you_already_published_repeated_N_times.reject
+++ b/you_already_published_repeated_N_times.reject
@@ -1,0 +1,18 @@
+The authors have tackled the problem of ... in this paper.
+However, the reviewer cannot find any deference between this paper
+and your paper "...," which has been already published.
+
+The authors have tackled the problem of ... in this paper.
+However, the reviewer cannot find any deference between this paper
+and your paper "...," which has been already published.
+
+The authors have tackled the problem of ... in this paper.
+However, the reviewer cannot find any deference between this paper
+and your paper "...," which has been already published.
+
+...
+(Repeat N times until the word count of your message exceeds
+the requirement of review system.)
+...
+
+The reviews were repeated N times, because it is very important.


### PR DESCRIPTION
Add a new template for rejecting duplicated submission, in cases where
a restriction on the number of words in describing your review exists.
